### PR TITLE
[#5] Add missing 'type' attribute to menu buttons.

### DIFF
--- a/react-prosemirror/src/MenuBar.js
+++ b/react-prosemirror/src/MenuBar.js
@@ -6,6 +6,7 @@ import classes from './MenuBar.module.css'
 const Button = (state, dispatch) => (item, key) => (
   <button
     key={key}
+    type="button"
     className={classnames({
       [classes.button]: true,
       [classes.active]: item.active && item.active(state)


### PR DESCRIPTION
As stated in the issue description, when `button` tag does not have `type` attribute, the default is a `submit` which results in submitting forms.

Resolves #5 