### PR TITLE
Fix list item shortcuts

### DIFF
--- a/react-prosemirror-config-default/src/nodes.js
+++ b/react-prosemirror-config-default/src/nodes.js
@@ -16,8 +16,7 @@ const listNodes = {
   },
   list_item: {
     ...listItem,
-    content: 'paragraph block*',
-    group: 'block'
+    content: 'paragraph block*'
   }
 }
 


### PR DESCRIPTION
Sink/lift list item functions weren't working correctly with this line.

list_items would become nested, causing bugs when trying to use cmd+[ or cmd+] shortcuts.