### PR TITLE
Update editor state on value change and expose editor view

### DIFF
--- a/react-prosemirror/src/Editor.js
+++ b/react-prosemirror/src/Editor.js
@@ -5,6 +5,7 @@ import 'prosemirror-view/style/prosemirror.css'
 import './Editor.css'
 
 class Editor extends React.Component {
+
   constructor (props) {
     super(props)
 
@@ -26,6 +27,14 @@ class Editor extends React.Component {
       attributes: this.props.attributes,
       nodeViews: this.props.nodeViews
     })
+  }
+
+  get view() {
+    return this._view;
+  }
+
+  set view(value) {
+    this._view = value;
   }
 
   componentDidMount () {

--- a/react-prosemirror/src/HtmlEditor.js
+++ b/react-prosemirror/src/HtmlEditor.js
@@ -4,35 +4,49 @@ import { DOMParser, DOMSerializer } from 'prosemirror-model'
 
 import Editor from './Editor'
 
-const parser = schema => {
-  const parser = DOMParser.fromSchema(schema)
-
-  return content => {
-    const container = document.createElement('article')
-    container.innerHTML = content
-
-    return parser.parse(container)
-  }
-}
-
-const serializer = schema => {
-  const serializer = DOMSerializer.fromSchema(schema)
-
-  return doc => {
-    const container = document.createElement('article')
-    container.appendChild(serializer.serializeFragment(doc.content))
-
-    return container.innerHTML
-  }
-}
-
 class HtmlEditor extends React.Component {
+
+  constructor (props) {
+    super(props)
+
+    this.editorRef = React.createRef()
+  }
+
+  get view() {
+    if (!this.editorRef || !this.editorRef.current) {
+      return null;
+    }
+    return this.editorRef.current.view;
+  }
+
+  initializeParse(schema) {
+    const parser = DOMParser.fromSchema(schema)
+  
+    return content => {
+      const container = document.createElement('article')
+      container.innerHTML = content
+  
+      return parser.parse(container)
+    }
+  }
+  
+  initializeSerialize(schema) {
+    const serializer = DOMSerializer.fromSchema(schema)
+  
+    return doc => {
+      const container = document.createElement('article')
+      container.appendChild(serializer.serializeFragment(doc.content))
+  
+      return container.innerHTML
+    }
+  }
+
   componentWillMount () {
     const { value, onChange, options } = this.props
     const { schema } = options
 
-    const parse = parser(schema)
-    const serialize = serializer(schema)
+    const parse = this.initializeParse(schema)
+    const serialize = this.initializeSerialize(schema)
 
     options.doc = parse(value)
 
@@ -41,11 +55,23 @@ class HtmlEditor extends React.Component {
     }, 1000, { maxWait: 5000 })
   }
 
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { value, options } = this.props
+    const { schema } = options
+
+    if (nextProps.value !== value) {
+      const parse = this.initializeParse(schema)
+      this.view.state.doc = parse(value)
+      this.view.updateState(this.view.state);
+    }
+  }
+
   render () {
     const { autoFocus, options, attributes, render, nodeViews } = this.props
 
     return (
       <Editor
+        ref={this.editorRef}
         autoFocus={autoFocus}
         options={options}
         attributes={attributes}


### PR DESCRIPTION
We've got a use case where we use `react-prosemirror` for a comment input.
When the user clicks a submit button, the input should be cleared and blurred.
To have an easier time achieving this, I've made two modifications.

Both modifications assume that you hold a ref to your editor, e.g.:
```
    <HtmlEditor
      ref={editorRef}
      ...
    />
```

### The view property 
The `view` property of `Editor` and `HtmlEditor` now exposes the `EditorView`. This makes it easy to blur the component without using selectors:
```
editorRef.current.view.dom.blur();
```

### Editor state update if value changes
If I want to clear the editor from the outside, the obvious way would be to just set the `value` provided in the `props` to `null`. Currently the `HtmlEditor` only serializes the value when the component is mounted. To compensate for that I added the following block:

```
  UNSAFE_componentWillReceiveProps(nextProps) {
    const { value, options } = this.props
    const { schema } = options

    if (nextProps.value !== value) {
      const parse = this.initializeParse(schema)
      this.view.state.doc = parse(value)
      this.view.updateState(this.view.state);
    }
  }
```

This is probably not ideal because `componentWillReceiveProps` got deprecated, but for now it does the job.

I also moved the methods for initializing the serializer and parser to class methods and renamed them. The reason for this change is to be able to reuse them. Since they are class members now, anyone with a reference to the editor can use these methods that were previously not exported.